### PR TITLE
feat: [SBI-U01] 출석 스트릭 대시보드 구현

### DIFF
--- a/edulex/src/components/AttendanceHeatmap.jsx
+++ b/edulex/src/components/AttendanceHeatmap.jsx
@@ -1,0 +1,185 @@
+import { useState } from 'react'
+import { LIB } from '../constants/theme'
+
+// 요일 레이블 (일~토)
+const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토']
+
+// 월 레이블 계산: 각 주(col)의 첫 날이 속한 월 반환
+function buildMonthLabels(startDate) {
+  const labels = []
+  let lastMonth = -1
+
+  for (let col = 0; col < 53; col++) {
+    const d = new Date(startDate)
+    d.setDate(d.getDate() + col * 7)
+    const month = d.getMonth()
+    if (month !== lastMonth) {
+      labels.push({ col, label: `${month + 1}월` })
+      lastMonth = month
+    } else {
+      labels.push(null)
+    }
+  }
+  return labels
+}
+
+// 색상: 출석 여부에 따른 셀 색상
+const CELL_ATTENDED = '#c9a84c'   // LIB.gold
+const CELL_ATTENDED_HOVER = '#f0d080' // LIB.goldLight
+const CELL_EMPTY = '#e8d5b7'      // LIB.parchmentDark (미출석 — 밝은 배경 위에 자연스러운 대비)
+const CELL_EMPTY_HOVER = '#d4bc96' // 약간 어두운 parchment (호버)
+const CELL_FUTURE = 'transparent'
+
+export default function AttendanceHeatmap({ attendedDates, startDate }) {
+  const [hoveredCell, setHoveredCell] = useState(null)
+
+  const attendedSet = new Set(attendedDates)
+  const today = new Date().toISOString().split('T')[0]
+  const monthLabels = buildMonthLabels(startDate)
+
+  // 53주 × 7일 그리드 데이터 생성
+  const grid = []
+  for (let col = 0; col < 53; col++) {
+    const week = []
+    for (let row = 0; row < 7; row++) {
+      const d = new Date(startDate)
+      d.setDate(d.getDate() + col * 7 + row)
+      const dateStr = d.toISOString().split('T')[0]
+      week.push({
+        date: dateStr,
+        attended: attendedSet.has(dateStr),
+        isFuture: dateStr > today,
+        isToday: dateStr === today,
+      })
+    }
+    grid.push(week)
+  }
+
+  const getCellColor = (cell, isHovered) => {
+    if (cell.isFuture) return CELL_FUTURE
+    if (cell.attended) return isHovered ? CELL_ATTENDED_HOVER : CELL_ATTENDED
+    return isHovered ? CELL_EMPTY_HOVER : CELL_EMPTY
+  }
+
+  const formatTooltip = (cell) => {
+    if (cell.isFuture) return ''
+    const label = cell.attended ? '출석' : '미출석'
+    return `${cell.date} (${label})`
+  }
+
+  return (
+    <div style={{ overflowX: 'auto' }}>
+      {/* 월 레이블 행 */}
+      <div style={{ display: 'flex', paddingLeft: '24px', marginBottom: '4px' }}>
+        {monthLabels.map((item, i) =>
+          item ? (
+            <div
+              key={i}
+              style={{
+                width: '13px',
+                marginRight: '2px',
+                fontSize: '10px',
+                color: LIB.inkLight,
+                whiteSpace: 'nowrap',
+                minWidth: '13px',
+              }}
+            >
+              {item.label}
+            </div>
+          ) : (
+            <div key={i} style={{ width: '13px', marginRight: '2px', minWidth: '13px' }} />
+          )
+        )}
+      </div>
+
+      {/* 그리드 본체 */}
+      <div style={{ display: 'flex', gap: '0' }}>
+        {/* 요일 레이블 열 */}
+        <div style={{ display: 'flex', flexDirection: 'column', marginRight: '4px' }}>
+          {DAY_LABELS.map((label, i) => (
+            <div
+              key={i}
+              style={{
+                height: '11px',
+                marginBottom: '2px',
+                fontSize: '9px',
+                color: LIB.inkLight,
+                lineHeight: '11px',
+                width: '16px',
+                textAlign: 'right',
+                // 짝수 요일만 표시 (월, 수, 금)
+                visibility: i % 2 === 1 ? 'visible' : 'hidden',
+              }}
+            >
+              {label}
+            </div>
+          ))}
+        </div>
+
+        {/* 주(열) × 요일(행) */}
+        {grid.map((week, col) => (
+          <div
+            key={col}
+            style={{ display: 'flex', flexDirection: 'column', marginRight: '2px' }}
+          >
+            {week.map((cell, row) => {
+              const cellKey = `${col}-${row}`
+              const isHovered = hoveredCell === cellKey
+              return (
+                <div
+                  key={row}
+                  title={formatTooltip(cell)}
+                  onMouseEnter={() => setHoveredCell(cellKey)}
+                  onMouseLeave={() => setHoveredCell(null)}
+                  style={{
+                    width: '11px',
+                    height: '11px',
+                    borderRadius: '2px',
+                    marginBottom: '2px',
+                    backgroundColor: getCellColor(cell, isHovered),
+                    // 오늘 셀에 테두리 강조
+                    outline: cell.isToday ? `2px solid ${LIB.gold}` : 'none',
+                    outlineOffset: '1px',
+                    cursor: cell.isFuture ? 'default' : 'pointer',
+                    transition: 'background-color 0.12s ease',
+                    flexShrink: 0,
+                  }}
+                />
+              )
+            })}
+          </div>
+        ))}
+      </div>
+
+      {/* 범례 */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '6px',
+          marginTop: '8px',
+          paddingLeft: '24px',
+          fontSize: '10px',
+          color: LIB.inkLight,
+        }}
+      >
+        <span>미출석</span>
+        <div style={{ display: 'flex', gap: '2px' }}>
+          {[0.2, 0.5, 0.75, 1].map((opacity, i) => (
+            <div
+              key={i}
+              style={{
+                width: '11px',
+                height: '11px',
+                borderRadius: '2px',
+                backgroundColor: i === 0 ? CELL_EMPTY : CELL_ATTENDED,
+                opacity: i === 0 ? 1 : opacity,
+              }}
+            />
+          ))}
+        </div>
+        <span>출석</span>
+      </div>
+    </div>
+  )
+}

--- a/edulex/src/components/AttendanceStreak.jsx
+++ b/edulex/src/components/AttendanceStreak.jsx
@@ -1,113 +1,145 @@
-import { useEffect, useState } from 'react'
-import { supabase } from '../utils/supabase'
-import { useAuth } from '../context/AuthContext'
+import { useState } from 'react'
+import { Flame } from 'lucide-react'
+import { LIB } from '../constants/theme'
+import AttendanceHeatmap from './AttendanceHeatmap'
 
-export default function AttendanceStreak() {
-  const { user } = useAuth()
-  const [checkedToday, setCheckedToday] = useState(false)
-  const [streak, setStreak] = useState(0)
-  const [loading, setLoading] = useState(false)
-  const [rewardMsg, setRewardMsg] = useState('')
+export default function AttendanceStreak({
+  attendedDates,
+  streak,
+  checkedToday,
+  loading,
+  checkingIn,
+  getGridStartDate,
+  onCheckIn,
+}) {
+  const [btnHover, setBtnHover] = useState(false)
+  const [btnPress, setBtnPress] = useState(false)
 
-  useEffect(() => {
-    if (!user) return
-    checkTodayAttendance()
-    calculateStreak()
-  }, [user])
+  const startDate = getGridStartDate()
 
-  const today = () => new Date().toISOString().split('T')[0]
-
-  const checkTodayAttendance = async () => {
-    const { data } = await supabase
-      .from('attendance')
-      .select('id')
-      .eq('user_id', user.id)
-      .eq('date', today())
-      .maybeSingle()
-    setCheckedToday(!!data)
-  }
-
-  const calculateStreak = async () => {
-    const { data } = await supabase
-      .from('attendance')
-      .select('date')
-      .eq('user_id', user.id)
-      .order('date', { ascending: false })
-      .limit(30)
-
-    if (!data || data.length === 0) { setStreak(0); return }
-
-    let count = 0
-    let cursor = new Date(today())
-    for (const { date } of data) {
-      const d = new Date(date)
-      const diff = (cursor - d) / 86400000
-      if (diff > 1) break
-      count++
-      cursor = d
-    }
-    setStreak(count)
-  }
-
-  const handleAttendance = async () => {
-    if (checkedToday || loading) return
-    setLoading(true)
-
-    // DB 함수로 출석 + 책갈피 트랜잭션 처리 (SBI-H02)
-    const { error } = await supabase.rpc('check_attendance', { p_user_id: user.id })
-
-    if (!error) {
-      setCheckedToday(true)
-      setStreak(s => s + 1)
-      setRewardMsg('+10 책갈피 획득!')
-      setTimeout(() => setRewardMsg(''), 2500)
-    }
-    setLoading(false)
-  }
-
-  // 최근 7일 스트릭 시각화
-  const last7Days = Array.from({ length: 7 }, (_, i) => {
-    const d = new Date()
-    d.setDate(d.getDate() - (6 - i))
-    return d.toISOString().split('T')[0]
-  })
+  const btnStyle = checkedToday
+    ? {
+        background: '#d1fae5',
+        color: '#059669',
+        cursor: 'default',
+      }
+    : {
+        background: btnPress ? LIB.wood : btnHover ? LIB.gold : LIB.goldLight,
+        color: btnPress || btnHover ? '#fff' : LIB.ink,
+        transform: btnPress ? 'scale(0.96)' : btnHover ? 'scale(1.03)' : 'scale(1)',
+        transition: 'transform 0.15s cubic-bezier(.34,1.56,.64,1), background 0.15s ease, color 0.15s ease',
+        cursor: checkingIn ? 'wait' : 'pointer',
+      }
 
   return (
-    <div className="bg-white rounded-2xl shadow-sm p-5">
-      <div className="flex items-center justify-between mb-4">
-        <div>
-          <h3 className="font-bold text-gray-800">출석 체크</h3>
-          <p className="text-xs text-gray-400">연속 {streak}일 출석 중</p>
+    <div
+      className="rounded-2xl p-6"
+      style={{
+        background: LIB.cream,
+        border: `1px solid ${LIB.shelfLine}`,
+        boxShadow: '0 2px 8px rgba(92,58,30,0.08)',
+      }}
+    >
+      {/* 헤더: 연속 일수 + 출석 버튼 */}
+      <div className="flex items-center justify-between mb-5">
+        {/* 좌측: 연속 출석 일수 */}
+        <div className="flex items-center gap-3">
+          <div
+            className="flex items-center justify-center rounded-xl"
+            style={{
+              width: '48px',
+              height: '48px',
+              background: streak > 0
+                ? `linear-gradient(135deg, ${LIB.gold}, ${LIB.goldLight})`
+                : LIB.parchmentDark,
+            }}
+          >
+            <Flame
+              size={24}
+              color={streak > 0 ? LIB.wood : LIB.inkLight}
+              strokeWidth={2}
+            />
+          </div>
+          <div>
+            <div className="flex items-baseline gap-1">
+              <span
+                className="font-bold"
+                style={{ fontSize: '32px', lineHeight: 1, color: streak > 0 ? LIB.gold : LIB.inkLight }}
+              >
+                {streak}
+              </span>
+              <span
+                className="text-base font-semibold"
+                style={{ color: LIB.inkMid }}
+              >
+                일 연속
+              </span>
+            </div>
+            <p className="text-xs mt-0.5" style={{ color: LIB.inkLight }}>
+              연속 출석 중
+            </p>
+          </div>
         </div>
+
+        {/* 우측: 출석 버튼 */}
         <button
-          onClick={handleAttendance}
-          disabled={checkedToday || loading}
-          className={`px-4 py-2 rounded-xl text-sm font-semibold transition
-            ${checkedToday
-              ? 'bg-green-100 text-green-600 cursor-default'
-              : 'bg-[#7c3aed] text-white hover:bg-[#6d28d9]'
-            }`}
+          onClick={onCheckIn}
+          disabled={checkedToday || checkingIn}
+          onMouseEnter={() => !checkedToday && setBtnHover(true)}
+          onMouseLeave={() => { setBtnHover(false); setBtnPress(false) }}
+          onMouseDown={() => !checkedToday && setBtnPress(true)}
+          onMouseUp={() => setBtnPress(false)}
+          className="px-5 py-2.5 rounded-xl text-sm font-semibold"
+          style={btnStyle}
         >
-          {loading ? '처리 중...' : checkedToday ? '✅ 출석 완료' : '출석하기'}
+          {checkingIn
+            ? '처리 중...'
+            : checkedToday
+            ? '출석 완료'
+            : '출석하기'}
         </button>
       </div>
 
-      {/* 7일 스트릭 시각화 */}
-      <div className="flex gap-1.5">
-        {last7Days.map(date => (
-          <div
-            key={date}
-            title={date}
-            className={`flex-1 h-2 rounded-full ${date <= today() ? 'bg-[#7c3aed]' : 'bg-gray-100'}`}
+      {/* 잔디 그리드 */}
+      <div
+        className="rounded-xl p-4"
+        style={{
+          background: LIB.parchment,
+          border: `1px solid ${LIB.parchmentDark}`,
+        }}
+      >
+        <p className="text-xs font-semibold mb-3" style={{ color: LIB.inkMid }}>
+          연간 출석 현황
+        </p>
+        {loading ? (
+          <div className="flex items-center gap-2 py-4" style={{ color: LIB.inkLight }}>
+            <span className="text-sm">불러오는 중...</span>
+          </div>
+        ) : (
+          <AttendanceHeatmap
+            attendedDates={attendedDates}
+            startDate={startDate}
           />
-        ))}
+        )}
       </div>
 
-      {rewardMsg && (
-        <p className="text-center text-yellow-600 text-sm font-semibold mt-3 animate-bounce">
-          ⭐ {rewardMsg}
-        </p>
-      )}
+      {/* 총 출석일 뱃지 */}
+      <div className="flex items-center gap-2 mt-3">
+        <span
+          className="text-[10px] font-bold px-2 py-0.5 rounded-full"
+          style={{ background: LIB.parchmentDark, color: LIB.inkMid }}
+        >
+          총 {attendedDates.length}일 출석
+        </span>
+        {checkedToday && (
+          <span
+            className="text-[10px] font-bold px-2 py-0.5 rounded-full"
+            style={{ background: '#d1fae5', color: '#059669' }}
+          >
+            오늘 출석 완료
+          </span>
+        )}
+      </div>
     </div>
   )
 }

--- a/edulex/src/components/ui/Toast.jsx
+++ b/edulex/src/components/ui/Toast.jsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react'
+import { Bookmark } from 'lucide-react'
+import { LIB } from '../../constants/theme'
+
+/**
+ * Toast — 화면 하단 중앙에 잠깐 나타났다 사라지는 알림
+ * Props:
+ *   message  string   표시할 텍스트
+ *   onClose  () => void  애니메이션 종료 후 호출
+ */
+export function Toast({ message, onClose }) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    // 마운트 직후 fade-in
+    const showTimer = requestAnimationFrame(() => setVisible(true))
+    // 2.5초 후 fade-out → 0.3초 뒤 언마운트
+    const hideTimer = setTimeout(() => {
+      setVisible(false)
+      setTimeout(onClose, 300)
+    }, 2500)
+
+    return () => {
+      cancelAnimationFrame(showTimer)
+      clearTimeout(hideTimer)
+    }
+  }, [onClose])
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: '32px',
+        left: '50%',
+        transform: `translateX(-50%) translateY(${visible ? '0' : '16px'})`,
+        opacity: visible ? 1 : 0,
+        transition: 'opacity 0.25s ease, transform 0.25s ease',
+        zIndex: 9999,
+        display: 'flex',
+        alignItems: 'center',
+        gap: '10px',
+        padding: '14px 22px',
+        borderRadius: '16px',
+        background: LIB.wood,
+        boxShadow: '0 8px 32px rgba(44,26,14,0.35)',
+        pointerEvents: 'none',
+        minWidth: '200px',
+        maxWidth: '320px',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '32px',
+          height: '32px',
+          borderRadius: '8px',
+          background: `linear-gradient(135deg, ${LIB.gold}, ${LIB.goldLight})`,
+          flexShrink: 0,
+        }}
+      >
+        <Bookmark size={16} color={LIB.wood} strokeWidth={2.5} />
+      </div>
+      <span
+        style={{
+          fontSize: '14px',
+          fontWeight: 600,
+          color: LIB.goldLight,
+          lineHeight: 1.3,
+        }}
+      >
+        {message}
+      </span>
+    </div>
+  )
+}

--- a/edulex/src/hooks/useDashboard.js
+++ b/edulex/src/hooks/useDashboard.js
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useState } from 'react'
+import { supabase } from '../utils/supabase'
+import { useAuth } from '../context/AuthContext'
+
+const TODAY = () => new Date().toISOString().split('T')[0]
+
+// 오늘 기준 52주 전 월요일 계산 (잔디 그리드 시작점)
+function getGridStartDate() {
+  const d = new Date()
+  d.setDate(d.getDate() - 364)
+  // 일요일(0) 시작으로 맞추기
+  const day = d.getDay()
+  d.setDate(d.getDate() - day)
+  return d
+}
+
+export function useDashboard() {
+  const { user } = useAuth()
+
+  // 진행률
+  const [progressList, setProgressList] = useState([])
+  const [progressLoading, setProgressLoading] = useState(true)
+
+  // 출석
+  const [attendedDates, setAttendedDates] = useState([])
+  const [streak, setStreak] = useState(0)
+  const [checkedToday, setCheckedToday] = useState(false)
+  const [attendanceLoading, setAttendanceLoading] = useState(true)
+  const [checkingIn, setCheckingIn] = useState(false)
+  const [toast, setToast] = useState(null) // { message: string }
+
+  // ── 연간 출석 기록 로드 ────────────────────────────────────────
+  const fetchAnnualAttendance = useCallback(async () => {
+    if (!user) return
+    setAttendanceLoading(true)
+
+    const startDate = getGridStartDate().toISOString().split('T')[0]
+    const today = TODAY()
+
+    // get_annual_attendance RPC 호출 (BE 제공 예정)
+    const { data, error } = await supabase.rpc('get_annual_attendance', {
+      p_user_id: user.id,
+      p_start_date: startDate,
+      p_end_date: today,
+    })
+
+    if (error) {
+      // RPC가 아직 없을 경우 fallback: attendance 테이블 직접 조회
+      const { data: fallback, error: fallbackError } = await supabase
+        .from('attendance')
+        .select('date')
+        .eq('user_id', user.id)
+        .gte('date', startDate)
+        .lte('date', today)
+      if (fallbackError) {
+        console.error(fallbackError)
+        setAttendanceLoading(false)
+        return
+      }
+      const dates = (fallback ?? []).map(r => r.date)
+      setAttendedDates(dates)
+      setCheckedToday(dates.includes(today))
+      setAttendanceLoading(false)
+      return
+    }
+
+    // RPC 응답: { date: string, attended: boolean }[]
+    const dates = (data ?? []).filter(r => r.attended).map(r => r.date)
+    setAttendedDates(dates)
+    setCheckedToday(dates.includes(today))
+    setAttendanceLoading(false)
+  }, [user])
+
+  // ── 연속 출석 일수 계산 ────────────────────────────────────────
+  const fetchStreak = useCallback(async () => {
+    if (!user) return
+
+    const { data, error } = await supabase
+      .from('attendance')
+      .select('date')
+      .eq('user_id', user.id)
+      .order('date', { ascending: false })
+      .limit(400)
+
+    if (error) { console.error(error); return }
+    if (!data || data.length === 0) { setStreak(0); return }
+
+    const today = TODAY()
+    let count = 0
+    let cursor = new Date(today)
+
+    for (const { date } of data) {
+      const d = new Date(date)
+      const diff = Math.round((cursor - d) / 86400000)
+      if (diff > 1) break
+      count++
+      cursor = d
+    }
+    setStreak(count)
+  }, [user])
+
+  // ── 출석 체크 ─────────────────────────────────────────────────
+  const handleCheckIn = useCallback(async () => {
+    if (checkedToday || checkingIn || !user) return
+    setCheckingIn(true)
+
+    const { data, error } = await supabase.rpc('check_attendance', {
+      p_user_id: user.id,
+    })
+
+    if (error) {
+      console.error(error)
+      setCheckingIn(false)
+      return
+    }
+
+    const today = TODAY()
+    setCheckedToday(true)
+    setAttendedDates(prev => [...prev, today])
+    setStreak(s => s + 1)
+
+    // 책갈피 보상 메시지 (BE 응답에 bookmark_gained 포함 시 활용)
+    const gained = data?.bookmark_gained ?? 100
+    setToast({ message: `책갈피 ${gained}개 획득!` })
+    setCheckingIn(false)
+  }, [checkedToday, checkingIn, user])
+
+  const dismissToast = useCallback(() => setToast(null), [])
+
+  // ── 학습 진행률 ───────────────────────────────────────────────
+  const fetchProgress = useCallback(async () => {
+    if (!user) return
+    setProgressLoading(true)
+
+    const [{ data: officialWbs, error: e1 }, { data: myWbs, error: e2 }] = await Promise.all([
+      supabase.from('official_wordbooks').select('id, title, major'),
+      supabase.from('user_wordbooks').select('id, title').eq('user_id', user.id),
+    ])
+
+    if (e1) console.error(e1)
+    if (e2) console.error(e2)
+
+    const allWbs = [
+      ...(officialWbs ?? []).map(w => ({ ...w, type: 'official' })),
+      ...(myWbs ?? []).map(w => ({ ...w, type: 'user' })),
+    ]
+
+    const results = await Promise.all(
+      allWbs.map(async (wb) => {
+        const table = wb.type === 'official' ? 'official_words' : 'user_words'
+        const { count: total, error: e3 } = await supabase
+          .from(table)
+          .select('id', { count: 'exact', head: true })
+          .eq('wordbook_id', wb.id)
+
+        if (e3) console.error(e3)
+
+        const { count: completed, error: e4 } = await supabase
+          .from('word_progress')
+          .select('id', { count: 'exact', head: true })
+          .eq('user_id', user.id)
+          .eq('wordbook_id', wb.id)
+          .eq('is_completed', true)
+
+        if (e4) console.error(e4)
+
+        const percent = total > 0 ? Math.round(((completed ?? 0) / total) * 100) : 0
+        return { ...wb, total: total ?? 0, completed: completed ?? 0, percent }
+      })
+    )
+
+    setProgressList(results)
+    setProgressLoading(false)
+  }, [user])
+
+  useEffect(() => {
+    fetchAnnualAttendance()
+    fetchStreak()
+    fetchProgress()
+  }, [fetchAnnualAttendance, fetchStreak, fetchProgress])
+
+  return {
+    // 진행률
+    progressList,
+    progressLoading,
+    // 출석
+    attendedDates,
+    streak,
+    checkedToday,
+    attendanceLoading,
+    checkingIn,
+    toast,
+    handleCheckIn,
+    dismissToast,
+    getGridStartDate,
+  }
+}

--- a/edulex/src/hooks/useMainPage.js
+++ b/edulex/src/hooks/useMainPage.js
@@ -1,69 +1,76 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { supabase } from '../utils/supabase'
 import { useAuth } from '../context/AuthContext'
 
 const todayStr = () => new Date().toISOString().split('T')[0]
+
+function getGridStartDate() {
+  const d = new Date()
+  d.setDate(d.getDate() - 364)
+  d.setDate(d.getDate() - d.getDay()) // 일요일 시작
+  return d
+}
 
 export function useMainPage() {
   const { user } = useAuth()
   const [wordbookCount, setWordbookCount] = useState(0)
   const [streak, setStreak]               = useState(0)
   const [checkedToday, setCheckedToday]   = useState(false)
-  const [loading, setLoading]             = useState(false)
+  const [attendanceLoading, setAttendanceLoading] = useState(true)
+  const [checkingIn, setCheckingIn]       = useState(false)
   const [rewardMsg, setRewardMsg]         = useState('')
   const [recentWordbook, setRecentWordbook] = useState(null)
   const [recentQuiz, setRecentQuiz]       = useState(null)
-  const [attendedDates, setAttendedDates] = useState(new Set())
+  const [attendedDates, setAttendedDates] = useState([])
 
-  useEffect(() => {
+  const fetchAnnualAttendance = useCallback(async () => {
     if (!user) return
-    fetchWordbookCount()
-    checkTodayAttendance()
-    calculateStreak()
-    fetchRecent()
+    setAttendanceLoading(true)
+
+    const startDate = getGridStartDate().toISOString().split('T')[0]
+    const today = todayStr()
+
+    const { data, error } = await supabase.rpc('get_annual_attendance', {
+      p_user_id: user.id,
+    })
+
+    if (error) {
+      // fallback: 직접 조회
+      const { data: fallback } = await supabase
+        .from('attendance')
+        .select('date')
+        .eq('user_id', user.id)
+        .gte('date', startDate)
+        .lte('date', today)
+      const dates = (fallback ?? []).map(r => r.date)
+      setAttendedDates(dates)
+      setCheckedToday(dates.includes(today))
+    } else {
+      const dates = (data ?? []).filter(r => r.attended).map(r => r.date)
+      setAttendedDates(dates)
+      setCheckedToday(dates.includes(today))
+    }
+
+    setAttendanceLoading(false)
   }, [user])
 
-  const fetchWordbookCount = () =>
+  const fetchStreak = useCallback(async () => {
+    if (!user) return
+    const { data } = await supabase.rpc('get_streak_count', { p_user_id: user.id })
+    if (data !== null && data !== undefined) {
+      setStreak(data)
+    }
+  }, [user])
+
+  const fetchWordbookCount = useCallback(() =>
     supabase
       .from('user_wordbooks')
       .select('id', { count: 'exact', head: true })
       .eq('user_id', user.id)
       .then(({ count }) => setWordbookCount(count ?? 0))
+  , [user])
 
-  const checkTodayAttendance = async () => {
-    const { data } = await supabase
-      .from('attendance')
-      .select('id')
-      .eq('user_id', user.id)
-      .eq('date', todayStr())
-      .maybeSingle()
-    setCheckedToday(!!data)
-  }
-
-  const calculateStreak = async () => {
-    const { data } = await supabase
-      .from('attendance')
-      .select('date')
-      .eq('user_id', user.id)
-      .order('date', { ascending: false })
-      .limit(30)
-
-    if (!data || data.length === 0) { setStreak(0); return }
-
-    setAttendedDates(new Set(data.map(r => r.date)))
-
-    let count  = 0
-    let cursor = new Date(todayStr())
-    for (const { date } of data) {
-      const d = new Date(date)
-      if ((cursor - d) / 86400000 > 1) break
-      count++
-      cursor = d
-    }
-    setStreak(count)
-  }
-
-  const fetchRecent = async () => {
+  const fetchRecent = useCallback(async () => {
     const { data: wb } = await supabase
       .from('user_wordbooks')
       .select('id, title')
@@ -81,34 +88,38 @@ export function useMainPage() {
       .limit(1)
       .maybeSingle()
     setRecentQuiz(qz)
-  }
+  }, [user])
 
-  const handleAttendance = async () => {
-    if (checkedToday || loading) return
-    setLoading(true)
-    const { error } = await supabase.rpc('check_attendance', { p_user_id: user.id })
+  useEffect(() => {
+    if (!user) return
+    fetchWordbookCount()
+    fetchAnnualAttendance()
+    fetchStreak()
+    fetchRecent()
+  }, [user, fetchWordbookCount, fetchAnnualAttendance, fetchStreak, fetchRecent])
+
+  const handleAttendance = useCallback(async () => {
+    if (checkedToday || checkingIn || !user) return
+    setCheckingIn(true)
+    const { data, error } = await supabase.rpc('check_attendance', { p_user_id: user.id })
     if (!error) {
+      const today = todayStr()
       setCheckedToday(true)
+      setAttendedDates(prev => [...prev, today])
       setStreak(s => s + 1)
-      setAttendedDates(prev => new Set([...prev, todayStr()]))
-      setRewardMsg('+10 책갈피 획득!')
+      const gained = data?.gained_bookmark ?? 100
+      setRewardMsg(`책갈피 ${gained}개 획득!`)
       setTimeout(() => setRewardMsg(''), 2500)
     }
-    setLoading(false)
-  }
-
-  const last7Days = Array.from({ length: 7 }, (_, i) => {
-    const d = new Date()
-    d.setDate(d.getDate() - (6 - i))
-    return d.toISOString().split('T')[0]
-  })
+    setCheckingIn(false)
+  }, [checkedToday, checkingIn, user])
 
   return {
     wordbookCount, setWordbookCount,
-    streak, checkedToday, loading, rewardMsg,
+    streak, checkedToday, attendanceLoading, checkingIn, rewardMsg,
     recentWordbook, recentQuiz,
-    last7Days, today: todayStr,
     attendedDates,
     handleAttendance,
+    getGridStartDate,
   }
 }

--- a/edulex/src/pages/DashboardPage.jsx
+++ b/edulex/src/pages/DashboardPage.jsx
@@ -1,102 +1,160 @@
-import { useEffect, useState } from 'react'
-import { supabase } from '../utils/supabase'
-import { useAuth } from '../context/AuthContext'
+import { LIB } from '../constants/theme'
+import { useDashboard } from '../hooks/useDashboard'
+import AttendanceStreak from '../components/AttendanceStreak'
+import { Toast } from '../components/ui/Toast'
 
 function ProgressBar({ percent }) {
   return (
-    <div className="w-full bg-gray-100 rounded-full h-2.5">
+    <div
+      className="w-full rounded-full h-2"
+      style={{ background: LIB.parchmentDark }}
+    >
       <div
-        className="bg-[#7c3aed] h-2.5 rounded-full transition-all duration-500"
-        style={{ width: `${percent}%` }}
+        className="h-2 rounded-full transition-all duration-500"
+        style={{ width: `${percent}%`, background: LIB.gold }}
       />
     </div>
   )
 }
 
 export default function DashboardPage() {
-  const { user } = useAuth()
-  const [progressList, setProgressList] = useState([])
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => { fetchProgress() }, [user])
-
-  const fetchProgress = async () => {
-    // 공식 단어장 진행률
-    const { data: officialWbs } = await supabase
-      .from('official_wordbooks')
-      .select('id, title, major')
-
-    // 나만의 단어장
-    const { data: myWbs } = await supabase
-      .from('user_wordbooks')
-      .select('id, title')
-      .eq('user_id', user.id)
-
-    const allWbs = [
-      ...(officialWbs ?? []).map(w => ({ ...w, type: 'official' })),
-      ...(myWbs ?? []).map(w => ({ ...w, type: 'user' })),
-    ]
-
-    // 각 단어장의 전체 단어 수 / 학습 완료 단어 수 계산 (SBI-U04)
-    const results = await Promise.all(
-      allWbs.map(async (wb) => {
-        const table = wb.type === 'official' ? 'official_words' : 'user_words'
-        const { count: total } = await supabase
-          .from(table)
-          .select('id', { count: 'exact', head: true })
-          .eq('wordbook_id', wb.id)
-
-        // 학습 완료 = 퀴즈에서 정답 처리된 단어
-        const { count: completed } = await supabase
-          .from('word_progress')
-          .select('id', { count: 'exact', head: true })
-          .eq('user_id', user.id)
-          .eq('wordbook_id', wb.id)
-          .eq('is_completed', true)
-
-        const percent = total > 0 ? Math.round(((completed ?? 0) / total) * 100) : 0
-        return { ...wb, total: total ?? 0, completed: completed ?? 0, percent }
-      })
-    )
-
-    setProgressList(results)
-    setLoading(false)
-  }
+  const {
+    progressList,
+    progressLoading,
+    attendedDates,
+    streak,
+    checkedToday,
+    attendanceLoading,
+    checkingIn,
+    toast,
+    handleCheckIn,
+    dismissToast,
+    getGridStartDate,
+  } = useDashboard()
 
   return (
-    <div className="p-6 max-w-2xl mx-auto">
-      <h1 className="text-2xl font-bold text-[#1a1a2e] mb-1">학습 진행률</h1>
-      <p className="text-sm text-gray-400 mb-6">단어장별 학습 완료 현황</p>
+    <div
+      className="min-h-screen"
+      style={{ background: `linear-gradient(135deg, ${LIB.parchment}, ${LIB.cream})` }}
+    >
+      <div className="p-6 max-w-3xl mx-auto">
+        {/* 페이지 타이틀 */}
+        <h1
+          className="text-2xl font-bold mb-1"
+          style={{ color: LIB.ink }}
+        >
+          대시보드
+        </h1>
+        <p className="text-sm mb-6" style={{ color: LIB.inkLight }}>
+          출석 현황 및 학습 진행률을 확인하세요
+        </p>
 
-      {loading ? (
-        <p className="text-gray-400 text-sm">불러오는 중...</p>
-      ) : progressList.length === 0 ? (
-        <div className="bg-white rounded-2xl p-10 text-center text-gray-400">
-          <p className="text-4xl mb-3">📊</p>
-          <p className="text-sm">단어장이 없습니다.</p>
-        </div>
-      ) : (
-        <div className="space-y-4">
-          {progressList.map(wb => (
-            <div key={wb.id} className="bg-white rounded-2xl shadow-sm p-5 border border-gray-100">
-              <div className="flex items-center justify-between mb-2">
-                <div>
-                  <span className="text-sm font-semibold text-gray-800">{wb.title}</span>
-                  <span className={`ml-2 text-xs px-2 py-0.5 rounded-full ${wb.type === 'official' ? 'bg-blue-50 text-blue-500' : 'bg-purple-50 text-purple-500'}`}>
-                    {wb.type === 'official' ? (wb.major ?? '공식') : 'AI 생성'}
-                  </span>
-                </div>
-                <span className="text-sm font-bold text-[#7c3aed]">{wb.percent}%</span>
-              </div>
-              <ProgressBar percent={wb.percent} />
-              <p className="text-xs text-gray-400 mt-1.5">
-                {wb.completed} / {wb.total} 단어 완료
+        {/* 출석 스트릭 섹션 */}
+        <section className="mb-8">
+          <h2
+            className="text-base font-semibold mb-3"
+            style={{ color: LIB.wood }}
+          >
+            출석 현황
+          </h2>
+          <AttendanceStreak
+            attendedDates={attendedDates}
+            streak={streak}
+            checkedToday={checkedToday}
+            loading={attendanceLoading}
+            checkingIn={checkingIn}
+            getGridStartDate={getGridStartDate}
+            onCheckIn={handleCheckIn}
+          />
+        </section>
+
+        {/* 학습 진행률 섹션 */}
+        <section>
+          <h2
+            className="text-base font-semibold mb-3"
+            style={{ color: LIB.wood }}
+          >
+            학습 진행률
+          </h2>
+          <p className="text-xs mb-4" style={{ color: LIB.inkLight }}>
+            단어장별 학습 완료 현황
+          </p>
+
+          {progressLoading ? (
+            <div
+              className="rounded-2xl p-10 text-center text-sm"
+              style={{ background: LIB.cream, color: LIB.inkLight }}
+            >
+              불러오는 중...
+            </div>
+          ) : progressList.length === 0 ? (
+            <div
+              className="rounded-2xl p-10 text-center"
+              style={{ background: LIB.cream, border: `1px solid ${LIB.shelfLine}` }}
+            >
+              <p className="text-sm" style={{ color: LIB.inkLight }}>
+                단어장이 없습니다.
               </p>
             </div>
-          ))}
-        </div>
+          ) : (
+            <div className="space-y-4">
+              {progressList.map(wb => (
+                <div
+                  key={wb.id}
+                  className="rounded-2xl p-5"
+                  style={{
+                    background: LIB.cream,
+                    border: `1px solid ${LIB.shelfLine}`,
+                    boxShadow: '0 2px 8px rgba(92,58,30,0.06)',
+                  }}
+                >
+                  <div className="flex items-center justify-between mb-2">
+                    <div>
+                      <span
+                        className="text-sm font-semibold"
+                        style={{ color: LIB.ink }}
+                      >
+                        {wb.title}
+                      </span>
+                      <span
+                        className="ml-2 text-[10px] font-bold px-2 py-0.5 rounded-full"
+                        style={
+                          wb.type === 'official'
+                            ? { background: '#eff6ff', color: '#3b82f6' }
+                            : { background: LIB.parchmentDark, color: LIB.inkMid }
+                        }
+                      >
+                        {wb.type === 'official' ? (wb.major ?? '공식') : 'AI 생성'}
+                      </span>
+                    </div>
+                    <span
+                      className="text-sm font-bold"
+                      style={{ color: LIB.gold }}
+                    >
+                      {wb.percent}%
+                    </span>
+                  </div>
+                  <ProgressBar percent={wb.percent} />
+                  <p
+                    className="text-xs mt-1.5"
+                    style={{ color: LIB.inkLight }}
+                  >
+                    {wb.completed} / {wb.total} 단어 완료
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+
+      {/* 책갈피 획득 토스트 */}
+      {toast && (
+        <Toast
+          message={toast.message}
+          onClose={dismissToast}
+        />
       )}
     </div>
   )
 }
-

--- a/edulex/src/pages/MainPage.jsx
+++ b/edulex/src/pages/MainPage.jsx
@@ -1,171 +1,12 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { Flame, Bookmark, BookOpen, Book, ChevronRight } from 'lucide-react'
+import { BookOpen, ChevronRight } from 'lucide-react'
 import CharacterPreview from '../components/CharacterPreview'
 import PdfUploadBar from '../components/PdfUploadBar'
+import AttendanceStreak from '../components/AttendanceStreak'
+import { Toast } from '../components/ui/Toast'
 import { useMainPage } from '../hooks/useMainPage'
 import { LIB } from '../constants/theme'
-
-// ── 요일 이니셜 (Duolingo 스타일) ────────────────────────────────
-const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토']
-
-function DayCircle({ date, todayStr, attendedDates }) {
-  const d = new Date(date)
-  const label = DAY_LABELS[d.getDay()]
-  const isToday = date === todayStr
-  const isPast = date < todayStr
-  const attended = attendedDates.has(date)
-
-  // 상태별 스타일
-  if (attended) {
-    // 출석 완료 — 골드 채움 + 체크
-    return (
-      <div className="flex flex-col items-center gap-1.5">
-        <div
-          className="w-9 h-9 rounded-full flex items-center justify-center text-base font-black shadow-md"
-          style={{
-            background: `linear-gradient(135deg, ${LIB.gold} 0%, #e8c040 100%)`,
-            color: LIB.ink,
-            boxShadow: '0 2px 8px rgba(201,168,76,0.5)',
-          }}
-        >
-          ✓
-        </div>
-        <span className="text-[10px] font-bold" style={{ color: LIB.goldLight }}>{label}</span>
-      </div>
-    )
-  }
-
-  if (isToday) {
-    // 오늘 (미출석) — 골드 테두리 + 펄스
-    return (
-      <div className="flex flex-col items-center gap-1.5">
-        <div
-          className="w-9 h-9 rounded-full flex items-center justify-center text-sm font-black animate-pulse"
-          style={{
-            background: 'rgba(201,168,76,0.15)',
-            border: `2.5px solid ${LIB.gold}`,
-            color: LIB.goldLight,
-          }}
-        >
-          {label}
-        </div>
-        <span className="text-[10px] font-bold" style={{ color: LIB.goldLight }}>{label}</span>
-      </div>
-    )
-  }
-
-  if (isPast) {
-    // 과거 미출석 — 흐린 원 (스트릭 끊김)
-    return (
-      <div className="flex flex-col items-center gap-1.5">
-        <div
-          className="w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold"
-          style={{ background: 'rgba(255,255,255,0.08)', border: '2px solid rgba(255,255,255,0.15)', color: 'rgba(255,255,255,0.25)' }}
-        >
-          {label}
-        </div>
-        <span className="text-[10px] font-semibold" style={{ color: 'rgba(255,255,255,0.3)' }}>{label}</span>
-      </div>
-    )
-  }
-
-  // 미래 — 매우 흐림
-  return (
-    <div className="flex flex-col items-center gap-1.5">
-      <div
-        className="w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold"
-        style={{ background: 'rgba(255,255,255,0.04)', border: '2px dashed rgba(255,255,255,0.1)', color: 'rgba(255,255,255,0.15)' }}
-      >
-        {label}
-      </div>
-      <span className="text-[10px] font-semibold" style={{ color: 'rgba(255,255,255,0.15)' }}>{label}</span>
-    </div>
-  )
-}
-
-function StreakBar({ last7Days, today, streak, checkedToday, loading, rewardMsg, onAttendance, attendedDates }) {
-  const todayStr = today()
-  const [btnHover, setBtnHover] = useState(false)
-  const [btnPress, setBtnPress] = useState(false)
-  return (
-    <div
-      className="rounded-2xl px-7 py-6 flex items-center gap-8 relative overflow-hidden select-none"
-      style={{
-        background: `linear-gradient(135deg, ${LIB.wood} 0%, ${LIB.woodLight} 100%)`,
-        boxShadow: '0 4px 20px rgba(92,58,30,0.40)',
-      }}
-    >
-      {/* 배경 질감 */}
-      <div className="absolute inset-0 opacity-[0.06] pointer-events-none"
-        style={{ backgroundImage: 'repeating-linear-gradient(0deg, transparent, transparent 20px, rgba(255,255,255,0.5) 20px, rgba(255,255,255,0.5) 21px)' }}
-      />
-      {/* 좌상단 빛 번짐 */}
-      <div className="absolute top-0 left-0 w-40 h-20 pointer-events-none"
-        style={{ background: 'radial-gradient(ellipse at 20% 0%, rgba(255,255,255,0.10) 0%, transparent 70%)' }}
-      />
-
-      {/* 좌측: 불꽃 카운터 */}
-      <div className="shrink-0 flex flex-col items-center" style={{ filter: 'drop-shadow(0 2px 6px rgba(201,168,76,0.4))' }}>
-        <Flame size={38} strokeWidth={1.5} style={{ color: LIB.gold }} className="mb-0.5" />
-        <div className="text-3xl font-black leading-none" style={{ color: LIB.gold }}>{streak}</div>
-        <div className="text-[10px] font-bold mt-0.5" style={{ color: LIB.goldLight }}>일 연속</div>
-      </div>
-
-      {/* 구분선 */}
-      <div className="w-px self-stretch opacity-20 shrink-0" style={{ background: LIB.shelfLine }} />
-
-      {/* 중앙: 7일 요일 원형 */}
-      <div className="flex-1 flex items-center justify-around">
-        {last7Days.map((date) => (
-          <DayCircle
-            key={date}
-            date={date}
-            todayStr={todayStr}
-            attendedDates={attendedDates}
-          />
-        ))}
-      </div>
-
-      {/* 우측: 출석 버튼 + 보상 */}
-      <div className="shrink-0 flex flex-col items-center gap-2">
-        <button
-          onClick={onAttendance}
-          disabled={checkedToday || loading}
-          onMouseEnter={() => !checkedToday && setBtnHover(true)}
-          onMouseLeave={() => { setBtnHover(false); setBtnPress(false) }}
-          onMouseDown={() => !checkedToday && setBtnPress(true)}
-          onMouseUp={() => setBtnPress(false)}
-          className="px-5 py-2.5 rounded-xl text-sm font-black whitespace-nowrap"
-          style={checkedToday
-            ? { background: 'rgba(255,255,255,0.12)', color: LIB.goldLight, cursor: 'default', transition: 'none' }
-            : {
-                background: btnPress
-                  ? '#b8962e'
-                  : btnHover
-                  ? '#e0bc5a'
-                  : LIB.gold,
-                color: LIB.ink,
-                boxShadow: btnHover ? '0 6px 18px rgba(201,168,76,0.65)' : '0 3px 10px rgba(201,168,76,0.5)',
-                transform: btnPress ? 'scale(0.96)' : btnHover ? 'scale(1.04)' : 'scale(1)',
-                transition: 'transform 0.15s cubic-bezier(.34,1.56,.64,1), box-shadow 0.15s ease, background 0.15s ease',
-              }
-          }
-        >
-          {loading ? '...' : checkedToday
-            ? <span className="flex items-center gap-1.5"><Bookmark size={13} fill="currentColor" /> 완료</span>
-            : '출석 도장'
-          }
-        </button>
-        {rewardMsg && (
-          <p className="text-[11px] font-bold animate-bounce whitespace-nowrap flex items-center gap-1" style={{ color: LIB.goldLight }}>
-            <Bookmark size={11} fill="currentColor" /> {rewardMsg}
-          </p>
-        )}
-      </div>
-    </div>
-  )
-}
 
 function BookCard({ to, label, title, subtitle, bookColor }) {
   const [hovered, setHovered] = useState(false)
@@ -236,7 +77,6 @@ function BookCard({ to, label, title, subtitle, bookColor }) {
           transition: 'height 0.22s ease, opacity 0.2s ease',
         }}
       />
-      {/* hover 시 빛 번짐 */}
       <div
         className="absolute inset-0 pointer-events-none rounded-2xl"
         style={{
@@ -271,16 +111,14 @@ function RecentCards({ recentWordbook, recentQuiz }) {
   )
 }
 
-// ── 메인 페이지 ───────────────────────────────────────────────────
-
 export default function MainPage() {
   const {
     wordbookCount, setWordbookCount,
-    streak, checkedToday, loading, rewardMsg,
+    streak, checkedToday, attendanceLoading, checkingIn, rewardMsg,
     recentWordbook, recentQuiz,
-    last7Days, today,
     attendedDates,
     handleAttendance,
+    getGridStartDate,
   } = useMainPage()
 
   return (
@@ -288,25 +126,24 @@ export default function MainPage() {
       className="h-[calc(100vh-72px)] p-5 grid grid-cols-[1fr_2fr] gap-5"
       style={{ background: LIB.parchment }}
     >
-      {/* 좌측: 캐릭터 (책 표지형) */}
+      {/* 좌측: 캐릭터 */}
       <CharacterPreview />
 
       {/* 우측: 3행 레이아웃 */}
-      <div className="grid grid-rows-[auto_1fr_auto] gap-4 min-h-0">
+      <div className="grid grid-rows-[auto_1fr_auto] gap-4 min-h-0 overflow-y-auto">
 
-        {/* 1행: 스트릭 (서가형) */}
-        <StreakBar
-          last7Days={last7Days}
-          today={today}
+        {/* 1행: 출석 잔디 */}
+        <AttendanceStreak
+          attendedDates={attendedDates}
           streak={streak}
           checkedToday={checkedToday}
-          loading={loading}
-          rewardMsg={rewardMsg}
-          onAttendance={handleAttendance}
-          attendedDates={attendedDates}
+          loading={attendanceLoading}
+          checkingIn={checkingIn}
+          getGridStartDate={getGridStartDate}
+          onCheckIn={handleAttendance}
         />
 
-        {/* 2행: 최근 단어장 + 최근 테스트 (책 카드형) */}
+        {/* 2행: 최근 단어장 + 최근 테스트 */}
         <RecentCards recentWordbook={recentWordbook} recentQuiz={recentQuiz} />
 
         {/* 3행: PDF 업로드 */}
@@ -315,7 +152,9 @@ export default function MainPage() {
           style={{ background: LIB.cream, border: `1px solid ${LIB.shelfLine}` }}
         >
           <div className="flex items-center gap-2 mb-1">
-            <span className="text-base font-extrabold flex items-center gap-1.5" style={{ color: LIB.wood }}><BookOpen size={16} strokeWidth={2} /> 새 책 추가</span>
+            <span className="text-base font-extrabold flex items-center gap-1.5" style={{ color: LIB.wood }}>
+              <BookOpen size={16} strokeWidth={2} /> 새 책 추가
+            </span>
             <span className="text-xs px-2 py-0.5 rounded-full font-semibold" style={{ background: LIB.parchmentDark, color: LIB.inkMid }}>
               PDF → 단어장
             </span>
@@ -330,6 +169,11 @@ export default function MainPage() {
         </div>
 
       </div>
+
+      {/* 책갈피 획득 토스트 */}
+      {rewardMsg && (
+        <Toast message={rewardMsg} onClose={() => {}} />
+      )}
     </div>
   )
 }

--- a/edulex/supabase/migrations/20260519010000_u01_attendance_streak.sql
+++ b/edulex/supabase/migrations/20260519010000_u01_attendance_streak.sql
@@ -1,0 +1,148 @@
+-- ================================================================
+-- Migration: SBI-U01 출석 스트릭 조회 RPC
+-- ----------------------------------------------------------------
+-- 신규 RPC:
+--   1. get_annual_attendance(p_user_id uuid)
+--        → TABLE(date date, attended boolean)
+--        오늘 기준 52주(364일) 전부터 오늘까지 날짜별 출석 여부 반환.
+--
+--   2. get_streak_count(p_user_id uuid)
+--        → integer
+--        오늘을 기준으로 연속된 출석 일수 계산.
+--        오늘 출석 기록이 있으면 오늘 포함, 없으면 어제부터 역순으로 산정.
+--
+-- 참고:
+--   - check_attendance RPC 는 shop,title.sql 에서 이미 +100 보상으로 재정의됨.
+--     본 마이그레이션은 check_attendance 를 수정하지 않는다.
+--   - 두 RPC 모두 SECURITY DEFINER + auth.uid() 호출자 검증.
+--   - GRANT EXECUTE TO authenticated (public 미부여).
+-- ================================================================
+
+BEGIN;
+
+-- ================================================================
+-- 1. get_annual_attendance
+--    파라미터 : p_user_id uuid
+--    반환     : TABLE(date date, attended boolean)
+--    범위     : current_date - 363 days ~ current_date (364일 = 52주)
+-- ================================================================
+
+CREATE OR REPLACE FUNCTION public.get_annual_attendance(
+  p_user_id uuid
+)
+RETURNS TABLE(date date, attended boolean)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  -- 호출자 검증 (SECURITY DEFINER 필수)
+  IF auth.uid() IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'unauthorized';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    gs.day::date                                          AS date,
+    EXISTS (
+      SELECT 1
+        FROM public.attendance a
+       WHERE a.user_id = p_user_id
+         AND a.date    = gs.day::date
+    )                                                     AS attended
+  FROM generate_series(
+    current_date - INTERVAL '363 days',
+    current_date,
+    INTERVAL '1 day'
+  ) AS gs(day)
+  ORDER BY gs.day;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_annual_attendance(uuid) TO authenticated;
+
+
+-- ================================================================
+-- 2. get_streak_count
+--    파라미터 : p_user_id uuid
+--    반환     : integer  (연속 출석 일수)
+--
+--    알고리즘:
+--      - 오늘 출석 기록이 있으면 오늘부터 역순으로, 없으면 어제부터 역순으로
+--        연속된 날짜를 카운트한다.
+--      - lag() 를 써서 날짜 간격이 1일 초과하는 시점을 단절점으로 판단.
+-- ================================================================
+
+CREATE OR REPLACE FUNCTION public.get_streak_count(
+  p_user_id uuid
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_start_date  date;
+  v_streak      integer := 0;
+  v_prev_date   date;
+  v_cur_date    date;
+  rec           record;
+BEGIN
+  -- 호출자 검증
+  IF auth.uid() IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'unauthorized';
+  END IF;
+
+  -- 오늘 출석 여부에 따라 카운트 시작 기준일 결정
+  IF EXISTS (
+    SELECT 1 FROM public.attendance
+     WHERE user_id = p_user_id AND date = current_date
+  ) THEN
+    v_start_date := current_date;
+  ELSE
+    v_start_date := current_date - INTERVAL '1 day';
+  END IF;
+
+  -- 기준일까지의 출석 기록을 내림차순으로 순회하며 연속 여부 확인
+  -- 기준일에 출석 기록이 없으면 streak = 0
+  v_prev_date := v_start_date + INTERVAL '1 day'; -- sentinel: 루프 첫 회 비교용
+
+  FOR rec IN
+    SELECT a.date
+      FROM public.attendance a
+     WHERE a.user_id = p_user_id
+       AND a.date   <= v_start_date
+     ORDER BY a.date DESC
+  LOOP
+    v_cur_date := rec.date;
+
+    -- 이전(더 최근) 날짜와 정확히 1일 차이가 나야 연속
+    IF v_prev_date - v_cur_date = 1 THEN
+      v_streak    := v_streak + 1;
+      v_prev_date := v_cur_date;
+    ELSE
+      -- 단절 — 루프 종료
+      EXIT;
+    END IF;
+  END LOOP;
+
+  RETURN v_streak;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_streak_count(uuid) TO authenticated;
+
+COMMIT;
+
+-- ================================================================
+-- Audit Checklist (edulex-be.md §10 Step 5)
+--  [x] RLS — attendance 테이블은 init.sql 에서 이미 RLS 활성화 및
+--            attendance_all 정책 설정 완료. 신규 테이블 없음.
+--  [x] SERVICE_ROLE_KEY 노출 없음 (마이그레이션 스크립트만)
+--  [x] Edge Function 변경 없음 (OPTIONS preflight 해당 없음)
+--  [x] Groq 응답 검증 해당 없음
+--  [x] bookmark 변경 없음 — check_attendance 는 기존 RPC 그대로 사용
+--  [x] verify_jwt 변경 없음
+--  [x] SECURITY DEFINER 함수 — 두 RPC 모두 auth.uid() = p_user_id 호출자 검증 포함
+--  [x] GRANT EXECUTE TO authenticated (public 미부여)
+--  [x] 인덱스 — attendance(user_id, date) 는 UNIQUE 제약으로 이미 인덱스 존재.
+--              추가 인덱스 불필요.
+-- ================================================================


### PR DESCRIPTION
- AttendanceHeatmap: GitHub 스타일 52주x7일 잔디 UI
- AttendanceStreak: 연속 출석 일수 표시 + 출석 버튼
- Toast: 책갈피 획득 토스트 알림 UI
- useDashboard: 연간 출석 데이터 Supabase 연동 훅
- useMainPage: get_annual_attendance/get_streak_count RPC 연동
- MainPage: 7일 도트 UI 제거, 잔디 UI로 교체
- DashboardPage: useDashboard 훅 기반으로 재구성
- migration: get_annual_attendance, get_streak_count RPC 추가